### PR TITLE
Make libacm.h usable from C++

### DIFF
--- a/src/libacm.h
+++ b/src/libacm.h
@@ -19,6 +19,10 @@
 #ifndef __LIBACM_H
 #define __LIBACM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LIBACM_VERSION "1.3"
 
 #define ACM_ID		0x032897
@@ -112,6 +116,10 @@ int acm_read_loop(ACMStream *acm, void *dst, unsigned len,
 int acm_seek_pcm(ACMStream *acm, unsigned pcm_pos);
 int acm_seek_time(ACMStream *acm, unsigned pos_ms);
 const char *acm_strerror(int err);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif
 


### PR DESCRIPTION
by conditionally adding extern "C"

Otherwise C++ code calling acm_* functions will assume they use C++ name mangling, when in reality they don't because the implementation is in plain C.